### PR TITLE
Fixes auth deprecation

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -29,8 +29,13 @@ const downloadFile = (assetId, output, githubToken, context) => new Promise(
         file.on('finish', resolve)
         file.on('error', failFn)
         Fetch(
-            `https://api.github.com/repos/${owner}/${repo}/releases/assets/${assetId}?access_token=${githubToken}`,
-            { headers: { 'Accept' : 'application/octet-stream' } }
+            `https://api.github.com/repos/${owner}/${repo}/releases/assets/${assetId}`,
+            { 
+                headers: { 
+                    'Accept' : 'application/octet-stream',
+                    'Authorization': `token ${githubToken}`
+                }
+            }
         ).then(res => res.body.pipe( file )).catch( failFn )
     }
 )


### PR DESCRIPTION
The workaround to downloading assets is now deprecated. Details here: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

This PR fixes it.