### PR TITLE
Fix strict settings

### DIFF
--- a/src/delete.js
+++ b/src/delete.js
@@ -1,4 +1,4 @@
-'use sstrict'
+'use strict'
 const Core = require('@actions/core')
 
 module.exports = async (octokit, context) => {

--- a/src/download.js
+++ b/src/download.js
@@ -1,4 +1,4 @@
-'use sstrict'
+'use strict'
 const Core = require('@actions/core')
 const FS = require('fs');
 const Path = require('path');

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const github = require('@actions/github')
 const Core = require('@actions/core')
 

--- a/src/update.js
+++ b/src/update.js
@@ -1,10 +1,10 @@
-'use sstrict'
+'use strict'
 const FS = require('fs')
 const Core = require('@actions/core')
 const Mime = require('mime-types')
 const Path = require('path');
 const {
-    findRelease, 
+    findRelease,
     splitAssetsString
 } = require('./utils')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-'use sstrict'
+'use strict'
 
 const splitAssetsString = assetStr => assetStr.split(';').filter(a => a)
 


### PR DESCRIPTION
It looks like these scripts were trying to use strict Javascript parsing, but had a typo in the directive. (Or maybe this is a different directive that I don't know about, I admit I do very little Javascript development. If that is the case, please just ignore this pull request. But I could not find any suggestion that this would do anything.)

Also, `index.js` was missing the directive entirely, and I thought you might want it there as well?